### PR TITLE
use journals settings structure to set EZID journals settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,55 @@ The plugin is triggered by the `preprint_publication` event. This event happens 
 
 ## Configuration
 
-The following keys need to be added, with appropriate values, to the settings.py file you're using for your Janeway installation:
+Configuration for preprints and journals is slightly different because preprints don't support the internal settings
+substructure that allows for press-wide defaults.
 
-```
-# EZID settings
-EZID_SHOULDER = 'doi:10.15697/'
-EZID_USERNAME = 'valid_username'
-EZID_PASSWORD = 'valid_password'
-EZID_ENDPOINT_URL = 'https://uc3-ezidx2-stg.cdlib.org'
-EZID_OWNER = 'account-name-of-whomever-should-be-billed'
-# ezid production URL is: https://ezid.cdlib.org
-# ezid staging URL is: https://uc3-ezidx2-stg.cdlib.org
-```
+### Preprints
+
+Each preprint repository needs to have an associated EZID Repo Settings object.
+
+1. Navigate to admin and find the "EZID" section
+1. Click "Add" Repo EZID settings
+1. Select the appropriate repository and fill in the shoulder, owner, username, password, and endpoint url
+1. Save
+
+### Journals
+
+Upon creation of a new press you should setup default values for EZID settings.
+
+1. Go to press manager https://<your-domain>/manager
+1. Click "Edit Journal Default Settings"
+1. Search for "ezid"
+1. EZID is enabled by default but may be changed press-wide or overriden per journal
+1. Fill in valid endpoint_url, username and password
+
+The EZID plugin also uses 3 values from the crossref settings and 1 other DOI-related setting you may choose to set press defaults for these
+or set them only on a per journal basis.
+
+1. Crossref depositor name
+1. Crossref depositor email
+1. Crossref registrant name
+1. Article DOI Pattern
+
+To override EZID settings for a particular journal:
+
+1. Go to journal dashboard > "Manager" > "All Settings"
+1. Search for "ezid"
+1. Create an override for each setting you want to override from the default
+
 
 ## Usage
 
+### Preprints 
+
 When installed and configured, the plugin will mint DOIs and add them to the system-created `preprint_doi` field for each newly-accepted preprint. Errors are logged.
+
+### Journals
+
+When an article is pushed to eScholarship with the janeway to escholarship plugin if the ezid plugin is installed and configured a doi is registered. DOIs are generated based on the Article DOI Pattern setting which is in line with Janeway functionality with Crossref.  There are also management commands that allow you to manually register or update a DOI associated with an article.
+
+`register_journal_ezid_doi <article_id>`
+`update_journal_ezid_doi <article_id>`
 
 ## Contributing
 

--- a/install/settings.json
+++ b/install/settings.json
@@ -1,0 +1,63 @@
+[
+    {
+      "group": {
+        "name": "plugin:ezid"
+      },
+      "setting": {
+        "description": "Enables and disables EZID plugin for this journal",
+        "is_translatable": false,
+        "name": "ezid_plugin_enable",
+        "pretty_name": "Enable EZID Plugin",
+        "type": "boolean"
+      },
+      "value": {
+        "default": "on"
+      }
+    },
+    {
+        "group": {
+          "name": "plugin:ezid"
+        },
+        "setting": {
+          "description": "EZID username to register DOIs",
+          "is_translatable": false,
+          "name": "ezid_plugin_username",
+          "pretty_name": "EZID username",
+          "type": "char"
+        },
+        "value": {
+          "default": ""
+        }
+      },
+      {
+        "group": {
+          "name": "plugin:ezid"
+        },
+        "setting": {
+          "description": "EZID password to register DOIs",
+          "is_translatable": false,
+          "name": "ezid_plugin_password",
+          "pretty_name": "EZID password",
+          "type": "char"
+        },
+        "value": {
+          "default": ""
+        }
+      },
+      {
+        "group": {
+          "name": "plugin:ezid"
+        },
+        "setting": {
+          "description": "EZID endpoint URL to register DOIs",
+          "is_translatable": false,
+          "name": "ezid_plugin_endpoint_url",
+          "pretty_name": "EZID endpoint URL",
+          "type": "char"
+        },
+        "value": {
+          "default": ""
+        }
+      }
+]
+  

--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -16,7 +16,7 @@ PLUGIN_NAME = 'EZID DOI Plugin'
 DISPLAY_NAME = 'EZID DOI'
 DESCRIPTION = 'Use EZID to deposit DOIs for preprints in Janeway.'
 AUTHOR = 'California Digital Library'
-VERSION = '0.2'
+VERSION = '0.3'
 SHORT_NAME = 'ezid'
 MANAGER_URL = 'ezid_manager'
 JANEWAY_VERSION = "1.3.8"
@@ -51,6 +51,11 @@ def install():
 
     else:
         print('Plugin {0} is already installed.'.format(PLUGIN_NAME))
+
+    update_settings(
+        file_path="plugins/ezid/install/settings.json"
+    )
+
 
 def register_for_events():
     '''register for events '''


### PR DESCRIPTION
Instead of using settings file settings we can use janeway settings for all the journals-related EZID settings.  Defaults can be set and then overridden in journals that require it.  Add some docs to this effect.