### PR TITLE
fixes for disabled EZID & corporate authors

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -267,7 +267,7 @@ def journal_article_doi(article, action, request):
 
         if not username or not password or not endpoint_url or not owner:
             msg = f"EZID not fully configured for {article.journal}"
-            if request: messages.error(msg)
+            if request: messages.error(request, msg)
             return True, False, msg
 
         path = f'id/doi:{encode(ezid_metadata["doi"])}'
@@ -277,7 +277,7 @@ def journal_article_doi(article, action, request):
         return True, (doi != None), ezid_result
     else:
         msg = f"EZID not enabled for {article.journal}"
-        if request: messages.warning(msg)
+        if request: messages.warning(request, msg)
         return False, False, msg
 
 def update_journal_doi(article, request=None):

--- a/logic.py
+++ b/logic.py
@@ -288,5 +288,6 @@ def register_journal_doi(article, request=None):
 
 def assign_article_doi(**kwargs):
     article = kwargs.get('article')
-    if not article.get_doi():
-        id = id_logic.generate_crossref_doi_with_pattern(article)
+    if get_setting('ezid_plugin_enable', article.journal):
+        if not article.get_doi():
+            id = id_logic.generate_crossref_doi_with_pattern(article)

--- a/templates/ezid/book_chapter.xml
+++ b/templates/ezid/book_chapter.xml
@@ -35,6 +35,9 @@
 			<content_item component_type="chapter" publication_type="full_text" language="en">
 				<contributors>
 					{% for a in article.frozen_authors.all %}
+					{% if a.is_corporate %}
+						<organization>{{ a.institution }}</organization>
+					{% else %}
 					<person_name contributor_role="author" sequence="{% if a.order == 0 %}first{% else %}additional{% endif %}">
 						<given_name>{{ a.given_names }}</given_name>
 						<surname>{{ a.last_name }}</surname>
@@ -42,6 +45,7 @@
 						<ORCID>https://orcid.org/{{ a.orcid }}</ORCID>
 						{% endif %}
 					</person_name>
+					{% endif %}
 					{% endfor %}
 				</contributors>
 				<titles>

--- a/templates/ezid/journal_content.xml
+++ b/templates/ezid/journal_content.xml
@@ -43,6 +43,9 @@
                 {% if article.frozen_authors.exists %}
                 <contributors>
                     {% for a in article.frozen_authors.all %}
+                    {% if a.is_corporate %}
+                    <organization>{{ a.institution }}</organization>
+                    {% else %}
                     <person_name contributor_role="author" sequence="{% if a.order == 0 %}first{% else %}additional{% endif %}">
                         <given_name>{{ a.given_names }}</given_name>
                         <surname>{{ a.last_name }}</surname>
@@ -50,6 +53,7 @@
                         <ORCID>https://orcid.org/{{ a.orcid }}</ORCID>
                         {% endif %}              
                     </person_name>
+                    {% endif %}
                     {% endfor %}
                  </contributors>
                  {% endif %}

--- a/templates/ezid/posted_content.xml
+++ b/templates/ezid/posted_content.xml
@@ -4,6 +4,9 @@
   {% if contributors %}
   <contributors>
       {% for contributor in contributors %}
+      {% if a.is_corporate %}
+        <organization>{{ a.institution }}</organization>
+      {% else %}
       <person_name contributor_role="author" {% if forloop.first %}sequence="first"{% else %}sequence="additional"{% endif %}>
           <given_name>{{ contributor.given_name|striptags|escape }}</given_name>
           <surname>{{ contributor.surname|striptags|escape }}</surname>
@@ -11,6 +14,7 @@
           <ORCID>{{ contributor.ORCID }}</ORCID>
           {% endif %}
       </person_name>
+      {% endif %}
       {% endfor %}
   </contributors>
   {% endif %}


### PR DESCRIPTION
- messages needs the request obj
- don't create a DOI obj if EZID is disabled
- add corporate author case to crossref templates