### PR TITLE
Check for empty license url

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -36,6 +36,14 @@ def get_valid_orcid(orcid):
     match = regex.match(str(orcid))
     return orcid if bool(match) else None
 
+
+def get_license_url(article):
+    if article and article.license and article.license.url :
+        url = article.license.url
+        if url.startswith('http'):
+            return url
+    return None
+
 def normalize_author_metadata(preprint_authors):
     ''' returns a list of authors in dictionary format using a list of author objects '''
     #example: {"given_name": "Hardy", "surname": "Pottinger", "ORCID": "https://orcid.org/0000-0001-8549-9354"},
@@ -164,7 +172,7 @@ def get_preprint_metadata(preprint):
                      'published_date': get_date_dict(preprint.date_published),
                      'accepted_date': get_date_dict(preprint.date_accepted),
                      'abstract': escape_str(preprint.abstract),
-                     'license': preprint.license.url if preprint.license else None}
+                     'license_url': get_license_url(preprint)}
 
     if preprint.doi:
         if is_valid_url(preprint.doi):
@@ -243,7 +251,8 @@ def get_journal_metadata(article):
             'depositor_name': setting_handler.get_setting('Identifiers', 'crossref_name', article.journal).processed_value,
             'depositor_email': setting_handler.get_setting('Identifiers', 'crossref_email', article.journal).processed_value,
             'registrant': setting_handler.get_setting('Identifiers', 'crossref_registrant', article.journal).processed_value,
-            'download_url': download_url,}
+            'download_url': download_url,
+            'license_url': get_license_url(article)}
 
 def get_journal_template(journal):
     return 'ezid/book_chapter.xml' if get_setting('ezid_book_chapter', journal) else 'ezid/journal_content.xml'

--- a/templates/ezid/book_chapter.xml
+++ b/templates/ezid/book_chapter.xml
@@ -31,7 +31,7 @@
           <publisher_name>eScholarship Publishing</publisher_name>
           <publisher_place>Oakland,CA</publisher_place>
         </publisher>
-        {% if article.license %}
+        {% if article.license and article.license.url and article.license.url.strip%}
         <program xmlns="http://www.crossref.org/AccessIndicators.xsd">
           <free_to_read/>
           <license_ref>{{article.license.url}}</license_ref>

--- a/templates/ezid/book_chapter.xml
+++ b/templates/ezid/book_chapter.xml
@@ -31,10 +31,10 @@
           <publisher_name>eScholarship Publishing</publisher_name>
           <publisher_place>Oakland,CA</publisher_place>
         </publisher>
-        {% if article.license and article.license.url and article.license.url.strip%}
+        {% if license_url%}
         <program xmlns="http://www.crossref.org/AccessIndicators.xsd">
           <free_to_read/>
-          <license_ref>{{article.license.url}}</license_ref>
+          <license_ref>{{license_url}}</license_ref>
 
         </program>
         {% endif %}

--- a/templates/ezid/journal_content.xml
+++ b/templates/ezid/journal_content.xml
@@ -69,10 +69,10 @@
                     <year>{{ article.date_published.year }}</year>
                 </publication_date>
 		{% endif %}
-		{% if article.license and article.license.url and article.license.url.strip %}
+		{% if license_url %}
 		<program xmlns="http://www.crossref.org/AccessIndicators.xsd">
 			<free_to_read/>
-			<license_ref>{{article.license.url}}</license_ref>
+			<license_ref>{{license_url}}</license_ref>
 		</program>
                 {% endif %}
                 <doi_data>

--- a/templates/ezid/journal_content.xml
+++ b/templates/ezid/journal_content.xml
@@ -69,7 +69,7 @@
                     <year>{{ article.date_published.year }}</year>
                 </publication_date>
 		{% endif %}
-		{% if article.license %}
+		{% if article.license and article.license.url and article.license.url.strip %}
 		<program xmlns="http://www.crossref.org/AccessIndicators.xsd">
 			<free_to_read/>
 			<license_ref>{{article.license.url}}</license_ref>

--- a/templates/ezid/posted_content.xml
+++ b/templates/ezid/posted_content.xml
@@ -36,7 +36,7 @@
     <jats:p>{{ abstract|striptags|escape }}</jats:p>
   </jats:abstract>
   {% endif %}
-  {% if license %}
+  {% if license and license.strip%}
   <program xmlns="http://www.crossref.org/AccessIndicators.xsd">
       <free_to_read/>
       <license_ref>{{license }}</license_ref>

--- a/templates/ezid/posted_content.xml
+++ b/templates/ezid/posted_content.xml
@@ -36,10 +36,10 @@
     <jats:p>{{ abstract|striptags|escape }}</jats:p>
   </jats:abstract>
   {% endif %}
-  {% if license and license.strip%}
+  {% if license_url%}
   <program xmlns="http://www.crossref.org/AccessIndicators.xsd">
       <free_to_read/>
-      <license_ref>{{license }}</license_ref>
+      <license_ref>{{license_url }}</license_ref>
   </program>
   {% endif %}
   {% if published_doi %}

--- a/tests.py
+++ b/tests.py
@@ -183,7 +183,7 @@ class EZIDJournalTest(TestCase):
         self.article.license = self.license
         self.article.save()
         path = "id/doi:10.9999/TEST"
-        payload = 'crossref: <?xml version="1.0" encoding="UTF-8"?> <doi_batch xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.3.1" xsi:schemaLocation="http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd"> <head> <doi_batch_id>JournalOne_20230101_10</doi_batch_id> <timestamp>1672531200</timestamp> <depositor> <depositor_name>crossref_test</depositor_name> <email_address>user1@test.edu</email_address> </depositor> <registrant>crossref_registrant</registrant> </head> <body> <journal> <journal_metadata> <full_title>Journal One</full_title> <abbrev_title>Journal One</abbrev_title> <issn media_type="electronic">1111-1111</issn> </journal_metadata> <journal_article publication_type="full_text"> <titles> <title>Test Article from Utils Testing Helpers</title> </titles> <program xmlns="http://www.crossref.org/AccessIndicators.xsd"> <free_to_read/> <license_ref>https://test.cc.org</license_ref> </program> <doi_data> <doi>10.9999/TEST</doi> <resource>https://test.org/qtXXXXXX</resource> <collection property="text-mining"> <item> <resource mime_type="application/pdf"> https://escholarship.org/content/qtqtXXXXXX/qtqtXXXXXX.pdf </resource> </item> </collection> </doi_data> </journal_article> </journal> </body> </doi_batch>\n_crossref: yes\n_profile: crossref\n_target: https://test.org/qtXXXXXX\n_owner: crossref_registrant'
+        payload = 'crossref: <?xml version="1.0" encoding="UTF-8"?> <doi_batch xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.3.1" xsi:schemaLocation="http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd"> <head> <doi_batch_id>JournalOne_20230101_11</doi_batch_id> <timestamp>1672531200</timestamp> <depositor> <depositor_name>crossref_test</depositor_name> <email_address>user1@test.edu</email_address> </depositor> <registrant>crossref_registrant</registrant> </head> <body> <journal> <journal_metadata> <full_title>Journal One</full_title> <abbrev_title>Journal One</abbrev_title> <issn media_type="electronic">1111-1111</issn> </journal_metadata> <journal_article publication_type="full_text"> <titles> <title>Test Article from Utils Testing Helpers</title> </titles> <program xmlns="http://www.crossref.org/AccessIndicators.xsd"> <free_to_read/> <license_ref>https://test.cc.org</license_ref> </program> <doi_data> <doi>10.9999/TEST</doi> <resource>https://test.org/qtXXXXXX</resource> <collection property="text-mining"> <item> <resource mime_type="application/pdf"> https://escholarship.org/content/qtqtXXXXXX/qtqtXXXXXX.pdf </resource> </item> </collection> </doi_data> </journal_article> </journal> </body> </doi_batch>\n_crossref: yes\n_profile: crossref\n_target: https://test.org/qtXXXXXX\n_owner: crossref_registrant'
         username = logic.get_setting('ezid_plugin_username', self.article.journal)
         password = logic.get_setting('ezid_plugin_password', self.article.journal)
         endpoint_url = logic.get_setting('ezid_plugin_endpoint_url', self.article.journal)
@@ -207,7 +207,33 @@ class EZIDJournalTest(TestCase):
         self.article.remote_url = None
         self.article.save()
         path = "id/doi:10.9999/TEST"
-        payload = f'crossref: <?xml version="1.0" encoding="UTF-8"?> <doi_batch xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.3.1" xsi:schemaLocation="http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd"> <head> <doi_batch_id>JournalOne_20230101_11</doi_batch_id> <timestamp>1672531200</timestamp> <depositor> <depositor_name>crossref_test</depositor_name> <email_address>user1@test.edu</email_address> </depositor> <registrant>crossref_registrant</registrant> </head> <body> <journal> <journal_metadata> <full_title>Journal One</full_title> <abbrev_title>Journal One</abbrev_title> <issn media_type="electronic">1111-1111</issn> </journal_metadata> <journal_article publication_type="full_text"> <titles> <title>Test Article from Utils Testing Helpers</title> </titles> <doi_data> <doi>10.9999/TEST</doi> <resource>None</resource> </doi_data> </journal_article> </journal> </body> </doi_batch>\n_crossref: yes\n_profile: crossref\n_target: None\n_owner: crossref_registrant'
+        payload = f'crossref: <?xml version="1.0" encoding="UTF-8"?> <doi_batch xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.3.1" xsi:schemaLocation="http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd"> <head> <doi_batch_id>JournalOne_20230101_12</doi_batch_id> <timestamp>1672531200</timestamp> <depositor> <depositor_name>crossref_test</depositor_name> <email_address>user1@test.edu</email_address> </depositor> <registrant>crossref_registrant</registrant> </head> <body> <journal> <journal_metadata> <full_title>Journal One</full_title> <abbrev_title>Journal One</abbrev_title> <issn media_type="electronic">1111-1111</issn> </journal_metadata> <journal_article publication_type="full_text"> <titles> <title>Test Article from Utils Testing Helpers</title> </titles> <doi_data> <doi>10.9999/TEST</doi> <resource>None</resource> </doi_data> </journal_article> </journal> </body> </doi_batch>\n_crossref: yes\n_profile: crossref\n_target: None\n_owner: crossref_registrant'
+        username = logic.get_setting('ezid_plugin_username', self.article.journal)
+        password = logic.get_setting('ezid_plugin_password', self.article.journal)
+        endpoint_url = logic.get_setting('ezid_plugin_endpoint_url', self.article.journal)
+
+        enabled, success, msg = logic.update_journal_doi(self.article)
+
+        mock_send.assert_called_once_with("POST", path, payload, username, password, endpoint_url)
+
+        self.assertTrue(enabled)
+        self.assertTrue(success)
+        self.assertEqual(msg, "success: doi:10.9999/TEST | ark:/b9999/test")
+
+
+    @freeze_time(FROZEN_DATETIME)
+    @mock.patch('plugins.ezid.logic.send_request', return_value="success: doi:10.9999/TEST | ark:/b9999/test")
+    def test_with_empty_license_doi(self, mock_send):
+        setting_handler.save_setting('general', 'journal_issn', self.article.journal, "1111-1111")
+        # if we don't clear the cache we get the old, invalid ISSN
+        cache.clear()
+        doi = Identifier.objects.create(id_type="doi", identifier="10.9999/TEST", article=self.article)
+        self.license.url = '  '
+        self.license.save()
+        self.article.license = self.license
+        self.article.save()
+        path = "id/doi:10.9999/TEST"
+        payload = 'crossref: <?xml version="1.0" encoding="UTF-8"?> <doi_batch xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5.3.1" xsi:schemaLocation="http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd"> <head> <doi_batch_id>JournalOne_20230101_10</doi_batch_id> <timestamp>1672531200</timestamp> <depositor> <depositor_name>crossref_test</depositor_name> <email_address>user1@test.edu</email_address> </depositor> <registrant>crossref_registrant</registrant> </head> <body> <journal> <journal_metadata> <full_title>Journal One</full_title> <abbrev_title>Journal One</abbrev_title> <issn media_type="electronic">1111-1111</issn> </journal_metadata> <journal_article publication_type="full_text"> <titles> <title>Test Article from Utils Testing Helpers</title> </titles> <doi_data> <doi>10.9999/TEST</doi> <resource>https://test.org/qtXXXXXX</resource> <collection property="text-mining"> <item> <resource mime_type="application/pdf"> https://escholarship.org/content/qtqtXXXXXX/qtqtXXXXXX.pdf </resource> </item> </collection> </doi_data> </journal_article> </journal> </body> </doi_batch>\n_crossref: yes\n_profile: crossref\n_target: https://test.org/qtXXXXXX\n_owner: crossref_registrant'
         username = logic.get_setting('ezid_plugin_username', self.article.journal)
         password = logic.get_setting('ezid_plugin_password', self.article.journal)
         endpoint_url = logic.get_setting('ezid_plugin_endpoint_url', self.article.journal)


### PR DESCRIPTION
Added check for empty license URL before including the license information in crossref xml.